### PR TITLE
Fix MKL when pkg-config fails

### DIFF
--- a/app/app.h
+++ b/app/app.h
@@ -9,7 +9,6 @@
 
 #ifndef APP_NAME
 #define APP_NAME "stdlite_app"
-#define APP_VERSION "unknown"
 #endif
 
 /**

--- a/app/meson.build
+++ b/app/meson.build
@@ -3,7 +3,6 @@ exe_args = []
 # build args
 app_build_args = build_args + [
     '-DAPP_NAME="' + meson.project_name() + '_run"',
-    '-DAPP_VERSION="' + meson.project_version() + '"',
 ]
 
 # dependencies
@@ -59,4 +58,6 @@ stdlite_exe = executable(
     c_args : app_build_args,
 )
 
-subdir('tests')
+if get_option('tests')
+    subdir('tests')
+endif

--- a/app/user_input_handler.c
+++ b/app/user_input_handler.c
@@ -373,7 +373,7 @@ int stdl_user_input_handler_fill_from_args(stdl_user_input_handler* inp, int arg
     struct arg_end* arg_end_;
     struct arg_file* arg_input, *arg_ctx_source, *arg_data_output;
     struct arg_dbl* arg_ctx_gammaJ, *arg_ctx_gammaK, *arg_ctx_ax;
-    struct arg_str* arg_ctx_source_type, *arg_ctx_ethr, *arg_ctx_e2thr;
+    struct arg_str* arg_ctx_source_type, *arg_ctx_ethr, *arg_ctx_e2thr, *arg_ctx_method;
     struct arg_int* arg_ctx_tda;
 
     int err = STDL_ERR_OK;
@@ -389,6 +389,7 @@ int stdl_user_input_handler_fill_from_args(stdl_user_input_handler* inp, int arg
             arg_ctx_gammaK = arg_dbl0(NULL, "ctx_gammaK", NULL, "gamma_K"),
             arg_ctx_ethr = arg_str0(NULL, "ctx_ethr", "<freq>", "ethr"),
             arg_ctx_e2thr = arg_str0(NULL, "ctx_e2thr", "<freq>", "e2thr"),
+            arg_ctx_method = arg_str0(NULL, "ctx_method", "str", "method"),
             arg_ctx_ax = arg_dbl0(NULL, "ctx_ax", NULL, "HF exchange"),
             arg_ctx_tda = arg_int0(NULL, "ctx_tda", "{0,1}", "use the Tamm-Dancoff approximation"),
             // end0
@@ -475,6 +476,16 @@ int stdl_user_input_handler_fill_from_args(stdl_user_input_handler* inp, int arg
         STDL_ERROR_CODE_HANDLE(err, goto _end);
 
         inp->ctx_e2thr = (float) val;
+    }
+
+    if(arg_ctx_method->count > 0) {
+        if(strcmp(arg_ctx_method->sval[0], "monopole") == 0) {
+            inp->ctx_method = STDL_METHOD_MONOPOLE;
+        } else if(strcmp(arg_ctx_method->sval[0], "monopole_direct") == 0) {
+            inp->ctx_method = STDL_METHOD_MONOPOLE_DIRECT;
+        } else {
+            STDL_ERROR_HANDLE_AND_REPORT(1, err = STDL_ERR_INPUT; goto _end, "unknown method `%s`", arg_ctx_method->sval[0]);
+        }
     }
 
     if(arg_ctx_ax->count > 0)

--- a/meson.build
+++ b/meson.build
@@ -55,6 +55,7 @@ elif la_backend == 'mkl'
       project_dep += cc.find_library('mkl_core')
       project_dep += cc.find_library('mkl_intel_ilp64')
       project_dep += cc.find_library('mkl_intel_thread')
+      project_dep += cc.find_library('iomp5')
     endif
   else
     dep_mkl = dependency('mkl-dynamic-ilp64-seq', required: false)
@@ -102,4 +103,6 @@ stdlite_lib_dep = declare_dependency(
 subdir('app')
 
 # tests
-subdir('tests')
+if get_option('tests')
+  subdir('tests')
+endif

--- a/meson.build
+++ b/meson.build
@@ -68,6 +68,7 @@ elif la_backend == 'mkl'
     endif
   endif
   build_args += '-DUSE_MKL'
+  build_args += '-DMKL_ILP64'
 endif
 
 h5noserial = cc.find_library('hdf5', required: false)

--- a/meson.build
+++ b/meson.build
@@ -48,9 +48,23 @@ if la_backend == 'openblas' or la_backend == 'default'
 elif la_backend == 'mkl'
   # found using `pkg-config --list-all | grep "mkl"`
   if get_option('openmp')
-    project_dep += dependency('mkl-dynamic-ilp64-iomp', required: true)
+    dep_mkl = dependency('mkl-dynamic-ilp64-iomp', required: false)
+    if dep_mkl.found()
+      project_dep += dep_mkl
+    else
+      project_dep += cc.find_library('mkl_core')
+      project_dep += cc.find_library('mkl_intel_ilp64')
+      project_dep += cc.find_library('mkl_intel_thread')
+    endif
   else
-    project_dep += dependency('mkl-dynamic-ilp64-seq', required: true)
+    dep_mkl = dependency('mkl-dynamic-ilp64-seq', required: false)
+    if dep_mkl.found()
+      project_dep += dep_mkl
+    else
+      project_dep += cc.find_library('mkl_core')
+      project_dep += cc.find_library('mkl_intel_ilp64')
+      project_dep += cc.find_library('mkl_sequential')
+    endif
   endif
   build_args += '-DUSE_MKL'
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -13,3 +13,10 @@ option(
     value: true,
     description: 'Use OpenMP',
 )
+
+option(
+    'tests',
+    type: 'boolean',
+    value: true,
+    description: 'Include tests',
+)


### PR DESCRIPTION
For some reasons, pkg-config for MKL requires one for openmp, which is not always available. 